### PR TITLE
Update split_fastq.sh

### DIFF
--- a/split_fastq.sh
+++ b/split_fastq.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -ue
+
 reads=test.fastq
 outputfolder=$PWD
 round=1
@@ -11,15 +14,13 @@ nl -n rz -w $mnl $reads > $outputfolder/fastq.sorted
 
 for paf in $outputfolder/round-$round/*.paf ; do
 
-    bin=$(basename $paf | cut -d . -f 1)
+	bin=$(basename $paf .paf)
 
-    join $outputfolder/fastq.sorted <( \
+	join $outputfolder/fastq.sorted <( \
 
 		join <( cat $outputfolder/fastqindex.txt ) <( awk '{print $1}' $paf | sort -u ) | \
 
 		awk '{print $2 "\n" $3 "\n" $4 "\n" $5}' | sort ) | \
 
 	sort | cut -d ' ' -f 2- > $outputfolder/round-$round/$bin.fastq
-
 done
-


### PR DESCRIPTION
add shebang + fast-fail, use tabs consistently and let `basename` strip extension

#FYI Since you're not using `chdir` anywhere you can replace all instances of `$outputfolder` with `"$PWD"` directly. The quotes will prevent issues if `$PWD` contains spaces or special characters

For readability you could consider using `declare` - it lets you enforce a type (eg. `-i` for number) or create a read-only variable